### PR TITLE
fix: update release configuration, bump @actions/core to 1.2.6

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,15 +4,15 @@
     "@semantic-release/release-notes-generator",
     ["@semantic-release/changelog", {
           "changelogFile": "docs/CHANGELOG.md"
-        }],
-     ["@semantic-release/git", {
+    }],
+    ["@semantic-release/npm", { "npmPublish": false, }],
+    ["@semantic-release/github", {
+          "assets": ["dist/**/*.{js,css}", "action.yml", "docs/**/*.md", "package*.{json}"],
+    }],
+    ["@semantic-release/git", {
           "assets": ["dist/**/*.{js,css}", "action.yml", "docs/**/*.md", "package*.{json}"],
           "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
-    ["@semantic-release/npm", { "npmPublish": false, }],
-     ["@semantic-release/github", {
-          "assets": ["dist/**/*.{js,css}", "action.yml", "docs/**/*.md", "package*.{json}"],
-     }],
   ],
   branches: ['main']
 }


### PR DESCRIPTION
`git` should be last in the `.releaserc`. I've done this to trigger a release as the dependabot PR did not push a new version.